### PR TITLE
chore: add laravel monorepo placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # e2e
 
 This repository uses an npm workspace monorepo setup. The `apps/web` directory contains a Next.js application.
+The `apps/laravel` directory is reserved for a Laravel application scaffolded separately.
 
 ## Development
 

--- a/apps/laravel/.gitignore
+++ b/apps/laravel/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/node_modules/
+.env

--- a/apps/laravel/README.md
+++ b/apps/laravel/README.md
@@ -1,0 +1,11 @@
+# Laravel Application
+
+This directory is reserved for a Laravel application inside the monorepo.
+
+To initialize the project, run:
+
+```
+composer create-project laravel/laravel .
+```
+
+This command requires internet access to fetch Laravel and its dependencies.

--- a/apps/laravel/composer.json
+++ b/apps/laravel/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "e2e/laravel-app",
+    "description": "Placeholder Laravel application",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder directory for a future Laravel app
- document Laravel workspace in README

## Testing
- `composer validate apps/laravel/composer.json`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890875a8e40832bb691091bb031b02b