### PR TITLE
Add Docker Compose setup for Laravel API

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  laravel:
+    image: bitnami/laravel:10
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./apps/laravel:/app
+    working_dir: /app
+    environment:
+      - APP_ENV=local
+      - APP_DEBUG=true
+    command: bash -c "composer install && php artisan key:generate && php artisan serve --host 0.0.0.0 --port 8000"


### PR DESCRIPTION
## Summary
- add docker-compose.yaml for running Laravel backend API

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68915f5014d0832b90a8514e15f12265